### PR TITLE
add warmup function to speed up the first embedding

### DIFF
--- a/backends/Cargo.toml
+++ b/backends/Cargo.toml
@@ -12,7 +12,7 @@ text-embeddings-backend-python = { path = "python", optional = true }
 text-embeddings-backend-candle = { path = "candle", optional = true }
 tokio = { version = "^1.25", features = ["sync"] }
 tracing = "^0.1"
-
+rand = "^0.8"
 [features]
 clap = ["dep:clap", "text-embeddings-backend-core/clap"]
 python = ["dep:text-embeddings-backend-python"]

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -205,6 +205,12 @@ pub async fn run(
         .await
         .context("Model backend is not healthy")?;
 
+    // Warmup
+    if backend.warmup(
+        max_input_length as u32,
+        max_batch_tokens as u32).await.is_ok() {
+        tracing::info!("Succeed doing warmup");
+    }
     let max_batch_requests = backend
         .max_batch_size
         .map(|s| {


### PR DESCRIPTION
With this PR, we can speed up the client's first embedding from ~700ms to ~8ms(model: `BAAI/bge-large-en-v1.5`) Also, this PR will work with the following `batch bucketing`  feature which is WIP.