### PR TITLE
Model download enhancing

### DIFF
--- a/core/src/download.rs
+++ b/core/src/download.rs
@@ -21,19 +21,17 @@ pub const ST_CONFIG_NAMES: [&str; 7] = [
 #[instrument(skip_all)]
 fn _weight_files_to_download<'a>(
     api_info: &'a RepoInfo,
-    model_type_str: &'a str,
+    weight_file_type_str: &'a str,
 ) -> Option<Vec<&'a str>> {
+    let ignored_file_contains = ["arguments", "args", "training", "medusa_lm_head"];
     let files: Vec<&str> = api_info
         .siblings
         .iter()
         .map(|s| s.rfilename.as_str())
         .filter(|f| {
-            f.contains(model_type_str)
+            f.contains(weight_file_type_str)
                 && f.split("/").count() == 1
-                && !f.contains("arguments")
-                && !f.contains("args")
-                && !f.contains("training")
-                && !f.contains("medusa_lm_head")
+                && ignored_file_contains.iter().all(|s| !f.contains(s))
         })
         .collect();
     if files.is_empty() {

--- a/core/src/download.rs
+++ b/core/src/download.rs
@@ -1,4 +1,7 @@
-use hf_hub::api::tokio::{ApiError, ApiRepo};
+use hf_hub::api::{
+    tokio::{ApiError, ApiRepo},
+    RepoInfo,
+};
 use std::path::PathBuf;
 use tracing::instrument;
 
@@ -13,27 +16,57 @@ pub const ST_CONFIG_NAMES: [&str; 7] = [
     "sentence_xlnet_config.json",
 ];
 
+/// Parses a [`RepoInfo`] object for model weight files to download. Returns a non-empty vector of
+/// model files that contains a model type str, if there are any.
+#[instrument(skip_all)]
+fn _weight_files_to_download<'a>(
+    api_info: &'a RepoInfo,
+    model_type_str: &'a str,
+) -> Option<Vec<&'a str>> {
+    let files: Vec<&str> = api_info
+        .siblings
+        .iter()
+        .map(|s| s.rfilename.as_str())
+        .filter(|f| {
+            f.contains(model_type_str)
+                && f.split("/").count() == 1
+                && !f.contains("arguments")
+                && !f.contains("args")
+                && !f.contains("training")
+                && !f.contains("medusa_lm_head")
+        })
+        .collect();
+    if files.is_empty() {
+        return None;
+    }
+    Some(files)
+}
+
 #[instrument(skip_all)]
 pub async fn download_artifacts(api: &ApiRepo) -> Result<PathBuf, ApiError> {
     let start = std::time::Instant::now();
 
     tracing::info!("Starting download");
 
-    api.get("config.json").await?;
-    api.get("tokenizer.json").await?;
-
-    let model_root = match api.get("model.safetensors").await {
-        Ok(p) => p,
-        Err(_) => {
-            let p = api.get("pytorch_model.bin").await?;
-            tracing::warn!("`model.safetensors` not found. Using `pytorch_model.bin` instead. Model loading will be significantly slower.");
-            p
-        }
-    }
+    let model_root = api
+        .get("config.json")
+        .await?
         .parent()
         .unwrap()
         .to_path_buf();
+    api.get("tokenizer.json").await?;
 
+    let api_info = api.info().await?;
+    let model_files = _weight_files_to_download(&api_info, "safetensors")
+        .or_else(|| {
+            tracing::warn!("`model.safetensors` not found. Using `pytorch_model.bin` instead. Model loading will be significantly slower.");
+            _weight_files_to_download(&api_info, "pytorch_model")
+        }).expect("No model files found as `safetensors` or `pytorch_model`");
+
+    // Download the model files
+    for file_name in model_files {
+        api.get(file_name).await?;
+    }
     tracing::info!("Model artifacts downloaded in {:?}", start.elapsed());
     Ok(model_root)
 }


### PR DESCRIPTION
# What does this PR do?

This PR enables a more general download schema based on the model files present in the model repository. Specifically, it looks for `safetensors` and `pytorch_model` within the root directory of the model. This enables models such as [intfloat/e5-mistral-7b-instruct](https://huggingface.co/intfloat/e5-mistral-7b-instruct/tree/main) and other models natively supported by the Python backend.

