### PR TITLE
Enable batch bucketing feature to increase the throughput for processing

### DIFF
--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -31,6 +31,18 @@ pub struct Backend {
     pub model_type: ModelType,
 }
 
+fn powers_of_two(max_value: u32) -> Vec<u32> {
+    let mut result = Vec::new();
+    let mut power: u32 = 1;
+
+    while power <= max_value {
+        result.push(power);
+        power *= 2;
+    }
+
+    result
+}
+
 impl Backend {
     pub fn new(
         model_path: PathBuf,
@@ -103,12 +115,20 @@ impl Backend {
         &self,
         mut max_input_length: u32,
         max_token: u32,
+        max_bs: Option<usize>
     ) -> Result<(), BackendError> {
         let read_env_var = |key: &str, default: u32| -> u32 {
             env::var(key).ok().map_or(default, |value| value.parse::<u32>().unwrap())
         };
         let seq_bucket_size: u32 = read_env_var("PAD_SEQUENCE_TO_MULTIPLE_OF", 128);
         let max_warmup_length: u32 = read_env_var("MAX_WARMUP_SEQUENCE_LENGTH", 1024);
+
+        let max_batch_size = match max_bs {
+            Some(value) => value as u32,
+            None => read_env_var("MAX_WARMUP_BATCH_SIZE", 8),
+        };
+        let batch_sizes: Vec<u32> = powers_of_two(max_batch_size);
+
         max_input_length = std::cmp::min(max_input_length, max_warmup_length);
         let mut seq_lengths: Vec<u32> = (seq_bucket_size..max_input_length+1).step_by(seq_bucket_size as usize).collect();
         if let Some(&last) = seq_lengths.last() {
@@ -116,13 +136,20 @@ impl Backend {
                 seq_lengths.push(max_input_length);
             }
         }
-        for &length in seq_lengths.iter() {
-            let batch = self.create_warmup_batch(length, max_token);
+
+        let mut shapes: Vec<(u32, u32)> = Vec::with_capacity(batch_sizes.len() * seq_lengths.len());
+        for batch_size in &batch_sizes {
+            for seq_length in &seq_lengths {
+                shapes.push((*batch_size, *seq_length));
+            }
+        }
+        for shape in shapes.iter() {
+            let batch = self.create_warmup_batch(*shape, max_token);
             match &self.model_type {
                 ModelType::Classifier => self.predict(batch).await.map(|_| ()),
                 ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
             }?;
-            tracing::info!("finish warmup for length: {}", length);
+            tracing::info!("finish warmup for batch: {}, length: {}", shape.0, shape.1);
         }
         Ok(())
     }
@@ -130,20 +157,35 @@ impl Backend {
     #[instrument(skip_all)]
     pub fn create_warmup_batch(
         &self,
-        length: u32,
+        shape: (u32, u32),
         max_token: u32,
     ) -> Batch {
-        let input_ids = (0..length).map(|_| rand::thread_rng().gen_range(0..max_token)).collect();
+        let (batch_size, length) = shape;
+        let mut batched_input_ids = Vec::new();
+        let mut batched_token_type_ids = Vec::new();
+        let mut batched_position_ids = Vec::new();
+        let mut cumulative_seq_lengths = Vec::with_capacity(batch_size as usize + 1);
+        let mut pooled_indices = Vec::with_capacity(batch_size as usize);
+        cumulative_seq_lengths.push(0);
+        let input_ids: Vec<u32> = (0..length).map(|_| rand::thread_rng().gen_range(0..max_token)).collect();
         let token_type_ids: Vec<u32> = vec![0; length as usize];
         let position_ids: Vec<u32> = (0..length).collect();
-        let cumulative_seq_lengths: Vec<u32> = vec![0, length - 1];
+        let mut current_length = 0;
+        for batch_id in 0..batch_size {
+            batched_input_ids.extend(input_ids.iter().cloned());
+            batched_token_type_ids.extend(token_type_ids.iter().cloned());
+            batched_position_ids.extend(position_ids.iter().cloned());
+            current_length += input_ids.len();
+            cumulative_seq_lengths.push(current_length as u32);
+            pooled_indices.push(batch_id);
+        }
         Batch {
-            input_ids,
-            token_type_ids,
-            position_ids,
+            input_ids: batched_input_ids,
+            token_type_ids: batched_token_type_ids,
+            position_ids: batched_position_ids,
             cumulative_seq_lengths,
             max_length: length,
-            pooled_indices: vec![0],
+            pooled_indices,
             raw_indices: vec![],
         }
     }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -205,8 +205,6 @@ pub async fn run(
         .await
         .context("Model backend is not healthy")?;
 
-    // Warmup
-    backend.warmup(max_input_length as u32, max_batch_tokens as u32).await.context("Error when doing warmup")?;
 
     let max_batch_requests = backend
         .max_batch_size
@@ -216,6 +214,11 @@ pub async fn run(
             s
         })
         .or(max_batch_requests);
+
+    // Warmup
+    backend.warmup(max_input_length as u32, max_batch_tokens as u32, max_batch_requests).await.context("Error when doing warmup")?;
+
+
     // Queue logic
     let queue = Queue::new(
         backend.padded_model,

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -1,5 +1,3 @@
-use std::env::set_var;
-
 use anyhow::Result;
 use clap::Parser;
 use mimalloc::MiMalloc;
@@ -128,11 +126,6 @@ struct Args {
     /// Unused for gRPC servers
     #[clap(long, env)]
     cors_allow_origin: Option<Vec<String>>,
-
-    /// Set the PYTHON_SERVER_MIN_PADDING environment variable. This increases the minimum
-    /// token padding for a batched input in the python server.
-    #[clap(long, env)]
-    python_min_padding: Option<u16>
 }
 
 #[tokio::main]
@@ -145,10 +138,6 @@ async fn main() -> Result<()> {
         text_embeddings_router::init_logging(args.otlp_endpoint.as_ref(), args.json_output);
 
     tracing::info!("{args:?}");
-
-    if let Some(min_padded_batch) = args.python_min_padding {
-        set_var("PYTHON_SERVER_MIN_PADDING", min_padded_batch.to_string())
-    }
 
     text_embeddings_router::run(
         args.model_id,


### PR DESCRIPTION
I used model `BAAI/bge-large-en-v1.5` as the backend, and send 256 requests in total from 8 processes at the same time to test the batched inference's throughput. Results showed before this PR, the throughput is `{query_number: 256}, {total_time: 1.6624267101287842}, {fps: 156.6307029987751}`, and after this PR, the throughput is: `{query_number: 256}, {total_time: 0.44424891471862793}, {fps: 613.7479437322461}`