### PR TITLE
fix bug when padded input sqquence length exceeds model config's max …

### DIFF
--- a/backends/python/server/text_embeddings_server/server.py
+++ b/backends/python/server/text_embeddings_server/server.py
@@ -26,7 +26,8 @@ class EmbeddingService(embed_pb2_grpc.EmbeddingServiceServicer):
         return embed_pb2.HealthResponse()
 
     async def Embed(self, request, context):
-        batch = self.model.batch_type.from_pb(request, self.model.device)
+        max_input_length = self.model.max_input_length
+        batch = self.model.batch_type.from_pb(request, self.model.device, max_input_length)
 
         embeddings = self.model.embed(batch)
 

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -127,8 +127,12 @@ impl Backend {
             Some(value) => value as u32,
             None => read_env_var("MAX_WARMUP_BATCH_SIZE", 8),
         };
-        let batch_sizes: Vec<u32> = powers_of_two(max_batch_size);
-
+        let mut batch_sizes: Vec<u32> = powers_of_two(max_batch_size);
+        if let Some(&last) = batch_sizes.last() {
+            if last < max_batch_size {
+                batch_sizes.push(max_batch_size);
+            }
+        }
         if max_warmup_length > max_input_length {
             tracing::warn!("max_warmup_length exceeds model's max_input_length limit, will replace it");
         }

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -129,6 +129,9 @@ impl Backend {
         };
         let batch_sizes: Vec<u32> = powers_of_two(max_batch_size);
 
+        if max_warmup_length > max_input_length {
+            tracing::warn!("max_warmup_length exceeds model's max_input_length limit, will replace it");
+        }
         max_input_length = std::cmp::min(max_input_length, max_warmup_length);
         let mut seq_lengths: Vec<u32> = (seq_bucket_size..max_input_length+1).step_by(seq_bucket_size as usize).collect();
         if let Some(&last) = seq_lengths.last() {


### PR DESCRIPTION
We did padding to times of `PAD_SEQUENCE_TO_MULTIPLE_OF` length. However, when the padded length exceeds the model's max input length limit, it will return embeddings of value `[None, None,......]`, this PR is to fix this issue.