### PR TITLE
Power of two batching in rust queue without padding

### DIFF
--- a/backends/python/server/text_embeddings_server/models/types.py
+++ b/backends/python/server/text_embeddings_server/models/types.py
@@ -1,4 +1,3 @@
-import math
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -37,10 +36,9 @@ class PaddedBatch(Batch):
     def from_pb(cls, pb: embed_pb2.EmbedRequest, device: torch.device) -> "PaddedBatch":
         max_length = round_up(pb.max_length, PAD_SEQUENCE_TO_MULTIPLE_OF)
         batch_size = len(pb.cu_seq_lengths) - 1
-        new_bs = 2 ** math.ceil(math.log2(batch_size))
         # Allocate padded tensors all at once
         all_tensors = torch.zeros(
-            [4, new_bs, max_length], dtype=torch.int32
+            [4, batch_size, max_length], dtype=torch.int32
         )
         for i, start_index in enumerate(pb.cu_seq_lengths[:-1]):
             end_index = pb.cu_seq_lengths[i + 1]

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -176,7 +176,7 @@ fn queue_blocking_task(
                         break;
                     }
                     // Break if not able to fill the next power of 2 batch
-                    let next_pow_2 = if metadata.len() & metadata.len() - 1 == 0 {
+                    let next_pow_2 = if metadata.len() & (metadata.len() - 1) == 0 {
                         metadata.len()
                     } else {
                         2_usize.pow((metadata.len() as f32).log2().ceil() as u32) - metadata.len()

--- a/core/src/queue.rs
+++ b/core/src/queue.rs
@@ -175,6 +175,15 @@ fn queue_blocking_task(
                     if Some(metadata.len()) == max_batch_requests {
                         break;
                     }
+                    // Break if not able to fill the next power of 2 batch
+                    let next_pow_2 = if metadata.len() & metadata.len() - 1 == 0 {
+                        metadata.len()
+                    } else {
+                        2_usize.pow((metadata.len() as f32).log2().ceil() as u32) - metadata.len()
+                    };
+                    if entries.len() < next_pow_2 {
+                        break;
+                    }
                 }
 
                 let batch_size = metadata.len();


### PR DESCRIPTION
# What does this PR do?

Enforces power of 2 batch size on Rust-side queue management to reduce unnecessary padding usage. This results in a measurable 8.5% improvement when run on the first 100,000 sentences of the all-nli dataset. Details of the benchmark are listed below:
- Model: [BAAI/bge-large-en-v1.5](https://huggingface.co/BAAI/bge-large-en-v1.5)
- Client side batch size: 32
- Execution mode: sequential
- Habana version: 1.16.1 (using #15 as baseline)

Results: 
- Python-side power of 2 padded batching: 124.53370 seconds (0.039851 s / batch)
- Rust-side power of 2 batching: 113.92759 seconds (0.036457 s / batch)



## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
