### PR TITLE
Update Cargo.lock for internal packages to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "backend-grpc-client"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "grpc-metadata",
  "prost 0.11.9",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "rand",
@@ -3945,7 +3945,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-candle"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "accelerate-src",
  "anyhow",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-core"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "clap",
  "nohash-hasher",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-python"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "backend-grpc-client",
  "nohash-hasher",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-core"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "async-channel",
  "hf-hub",
@@ -4013,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-router"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
# What does this PR do?

Updates `Cargo.lock` to update internal package numbers. Patch for #20. 
